### PR TITLE
feat(pagerduty-user): Add support for setting role

### DIFF
--- a/examples/pagerduty-user/README.md
+++ b/examples/pagerduty-user/README.md
@@ -30,6 +30,7 @@ No resources.
 | <a name="input_email_address"></a> [email\_address](#input\_email\_address) | The email adddress of the user | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name to set for the user | `string` | n/a | yes |
 | <a name="input_pagerduty_token"></a> [pagerduty\_token](#input\_pagerduty\_token) | PagerDuty API token. | `string` | n/a | yes |
+| <a name="input_role"></a> [role](#input\_role) | The user's role in PagerDuty. Can be `admin`, `limited_user`, or `user`. | `string` | `"user"` | no |
 
 ## Outputs
 

--- a/examples/pagerduty-user/inputs.tf
+++ b/examples/pagerduty-user/inputs.tf
@@ -12,3 +12,7 @@ variable "pagerduty_token" {
   type        = string
   description = "PagerDuty API token."
 }
+variable "role" {
+  default     = "user"
+  description = "The user's role in PagerDuty. Can be `admin`, `limited_user`, or `user`."
+}

--- a/examples/pagerduty-user/main.tf
+++ b/examples/pagerduty-user/main.tf
@@ -3,4 +3,5 @@ module "user" {
 
   name          = var.name
   email_address = var.email_address
+  role          = var.role
 }

--- a/modules/pagerduty-user/README.md
+++ b/modules/pagerduty-user/README.md
@@ -29,8 +29,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_email_address"></a> [email\_address](#input\_email\_address) | The email adddress of the user | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | The name to set for the user | `string` | n/a | yes |
+| <a name="input_email_address"></a> [email\_address](#input\_email\_address) | The email address of the user. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name to set for the user. | `string` | n/a | yes |
+| <a name="input_role"></a> [role](#input\_role) | The user's role in PagerDuty. Can be `admin`, `limited_user`, or `user`. | `string` | `"user"` | no |
 
 ## Outputs
 

--- a/modules/pagerduty-user/inputs.tf
+++ b/modules/pagerduty-user/inputs.tf
@@ -1,9 +1,23 @@
 variable "email_address" {
-  description = "The email adddress of the user"
+  description = "The email address of the user."
   type        = string
 }
 
 variable "name" {
-  description = "The name to set for the user"
+  description = "The name to set for the user."
   type        = string
+}
+
+variable "role" {
+  default     = "user"
+  description = "The user's role in PagerDuty. Can be `admin`, `limited_user`, or `user`."
+  type        = string
+  validation {
+    condition = anytrue([
+      var.role == "admin",
+      var.role == "limited_user",
+      var.role == "user",
+    ])
+    error_message = "role must be one of `admin`, `limited_user`, or `user`."
+  }
 }

--- a/modules/pagerduty-user/user.tf
+++ b/modules/pagerduty-user/user.tf
@@ -1,4 +1,6 @@
 resource "pagerduty_user" "user" {
   name  = var.name
   email = var.email_address
+
+  role = var.role
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

Add the ability to set a role for PagerDuty users (so we can create admins, normal users, limited users, etc)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-pagerduty-alerting/10)
<!-- Reviewable:end -->
