### PR TITLE
chore: remove experiment, require terraform 1.3+

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -9,6 +9,10 @@ on:
 
 jobs:
   main:
-    name: semantic-pr
-    uses: honestbank/workflows/.github/workflows/general-semantic-pr.yaml@main
-    secrets: inherit
+    name: Semantic Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        name: Semantic Pull Request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ in Notion.
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | >= 2.2 |
 
 ## Providers

--- a/examples/honest-two-level-schedule/providers.tf
+++ b/examples/honest-two-level-schedule/providers.tf
@@ -5,8 +5,6 @@ terraform {
       version = ">= 2.2"
     }
   }
-
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "pagerduty" {

--- a/examples/pagerduty-escalation-policy/providers.tf
+++ b/examples/pagerduty-escalation-policy/providers.tf
@@ -5,8 +5,6 @@ terraform {
       version = ">= 2.2"
     }
   }
-
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "pagerduty" {

--- a/examples/pagerduty-schedule/providers.tf
+++ b/examples/pagerduty-schedule/providers.tf
@@ -5,8 +5,6 @@ terraform {
       version = ">= 2.2"
     }
   }
-
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "pagerduty" {

--- a/examples/pagerduty-user/providers.tf
+++ b/examples/pagerduty-user/providers.tf
@@ -5,8 +5,6 @@ terraform {
       version = ">= 2.2"
     }
   }
-
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "pagerduty" {

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,11 @@
 terraform {
+  required_version = ">= 1.3.0"
   required_providers {
     pagerduty = {
       source  = "pagerduty/pagerduty"
       version = ">= 2.2"
     }
   }
-
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "pagerduty" {

--- a/modules/honest-two-level-schedule/README.md
+++ b/modules/honest-two-level-schedule/README.md
@@ -9,6 +9,7 @@ time.
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | >= 2.2 |
 
 ## Providers

--- a/modules/honest-two-level-schedule/providers.tf
+++ b/modules/honest-two-level-schedule/providers.tf
@@ -1,10 +1,10 @@
 terraform {
+  required_version = ">= 1.3.0"
+
   required_providers {
     pagerduty = {
       source  = "pagerduty/pagerduty"
       version = ">= 2.2"
     }
   }
-
-  experiments = [module_variable_optional_attrs]
 }

--- a/modules/pagerduty-escalation-policy/README.md
+++ b/modules/pagerduty-escalation-policy/README.md
@@ -7,6 +7,7 @@ This module creates a PagerDuty Escalation Policy.
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | >= 2.2 |
 
 ## Providers

--- a/modules/pagerduty-escalation-policy/providers.tf
+++ b/modules/pagerduty-escalation-policy/providers.tf
@@ -1,10 +1,10 @@
 terraform {
+  required_version = ">= 1.3.0"
+
   required_providers {
     pagerduty = {
       source  = "pagerduty/pagerduty"
       version = ">= 2.2"
     }
   }
-
-  experiments = [module_variable_optional_attrs]
 }

--- a/modules/pagerduty-schedule/README.md
+++ b/modules/pagerduty-schedule/README.md
@@ -3,13 +3,14 @@
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | >= 2.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | 2.5.2 |
+| <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | >= 2.2 |
 
 ## Modules
 

--- a/modules/pagerduty-schedule/providers.tf
+++ b/modules/pagerduty-schedule/providers.tf
@@ -1,10 +1,10 @@
 terraform {
+  required_version = ">= 1.3.0"
+
   required_providers {
     pagerduty = {
       source  = "pagerduty/pagerduty"
       version = ">= 2.2"
     }
   }
-
-  experiments = [module_variable_optional_attrs]
 }

--- a/modules/pagerduty-service/README.md
+++ b/modules/pagerduty-service/README.md
@@ -7,13 +7,14 @@ This module creates a PagerDuty Service.
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | >= 2.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | 2.5.2 |
+| <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | >= 2.2 |
 
 ## Modules
 

--- a/modules/pagerduty-service/providers.tf
+++ b/modules/pagerduty-service/providers.tf
@@ -1,10 +1,10 @@
 terraform {
+  required_version = ">= 1.3.0"
+
   required_providers {
     pagerduty = {
       source  = "pagerduty/pagerduty"
       version = ">= 2.2"
     }
   }
-
-  experiments = [module_variable_optional_attrs]
 }

--- a/modules/pagerduty-user/README.md
+++ b/modules/pagerduty-user/README.md
@@ -7,13 +7,14 @@ This module creates a PagerDuty user.
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | >= 2.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | 2.5.2 |
+| <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | >= 2.2 |
 
 ## Modules
 

--- a/modules/pagerduty-user/providers.tf
+++ b/modules/pagerduty-user/providers.tf
@@ -1,10 +1,10 @@
 terraform {
+  required_version = ">= 1.3.0"
+
   required_providers {
     pagerduty = {
       source  = "pagerduty/pagerduty"
       version = ">= 2.2"
     }
   }
-
-  experiments = [module_variable_optional_attrs]
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description
* This PR removes Terraform `module_variable_optional_attrs` experiment in order to be able to use Terraform 1.3+.
* Followed this documentation advise: https://www.terraform.io/language/upgrade-guides#concluding-the-optional-attributes-experiment

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-pagerduty-alerting/11)
<!-- Reviewable:end -->
