### PR TITLE
feat: add 'teams' feature to escalation policy

### DIFF
--- a/examples/pagerduty-business-service/outputs.tf
+++ b/examples/pagerduty-business-service/outputs.tf
@@ -1,4 +1,4 @@
 output "business_service_id" {
   description = "The ID of the just created service"
-  value = module.pagerduty_business_service.id
+  value       = module.pagerduty_business_service.id
 }

--- a/examples/pagerduty-escalation-policy/main.tf
+++ b/examples/pagerduty-escalation-policy/main.tf
@@ -114,6 +114,12 @@ module "level_three_product_schedule" {
   user_ids = [module.product_lead.id]
 }
 
+module "mock_team" {
+  source      = "../../modules/pagerduty-team"
+  name        = "${var.name} team"
+  description = "Created by terratest"
+}
+
 module "escalation_policy" {
   source = "../../modules/pagerduty-escalation-policy"
 
@@ -127,4 +133,8 @@ module "escalation_policy" {
     [module.level_two_engineering_schedule.id, module.level_two_product_schedule.id],
     [module.level_three_engineering_schedule.id, module.level_three_product_schedule.id],
   ])
+
+  teams_id = [
+    module.mock_team.id,
+  ]
 }

--- a/modules/pagerduty-escalation-policy/escalation-policy.tf
+++ b/modules/pagerduty-escalation-policy/escalation-policy.tf
@@ -16,4 +16,6 @@ resource "pagerduty_escalation_policy" "escalation_policy" {
       }
     }
   }
+
+  teams = var.teams_id
 }

--- a/modules/pagerduty-escalation-policy/inputs.tf
+++ b/modules/pagerduty-escalation-policy/inputs.tf
@@ -16,3 +16,9 @@ variable "name" {
   description = "The name to set for the schedules and the schedule layers."
   type        = string
 }
+
+variable "teams_id" {
+  description = "(Optional) Teams associated with the policy."
+  type        = list(string)
+  default     = []
+}

--- a/test/pagerduty_escalation_policy_test.go
+++ b/test/pagerduty_escalation_policy_test.go
@@ -1,71 +1,72 @@
 package test
 
 import (
-	"context"
-	"log"
-	"testing"
+  "context"
+  "log"
+  "testing"
 
-	"github.com/PagerDuty/go-pagerduty"
-	"github.com/gruntwork-io/terratest/modules/terraform"
-	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
-	"github.com/stretchr/testify/assert"
+  "github.com/PagerDuty/go-pagerduty"
+  "github.com/gruntwork-io/terratest/modules/terraform"
+  test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+  "github.com/stretchr/testify/assert"
 )
 
 func TestPagerdutyEscalationPolicy(t *testing.T) {
-	workingDir := test_structure.CopyTerraformFolderToTemp(t, "..", "examples/pagerduty-escalation-policy")
-	workingDir = "../examples/pagerduty-escalation-policy"
+  workingDir := test_structure.CopyTerraformFolderToTemp(t, "..", "examples/pagerduty-escalation-policy")
+  workingDir = "../examples/pagerduty-escalation-policy"
 
-	log.Println("working dir for this test is: ", workingDir)
+  log.Println("working dir for this test is: ", workingDir)
 
-	escalationPolicyId := ""
-	runID := generateRunId()
-	test_structure.RunTestStage(t, "create_escalation_policy", func() {
-		escalationPolicyId = createEscalationPolicy(t, workingDir, runID)
-		log.Println("created escalation policy ID: ", escalationPolicyId)
-	})
+  escalationPolicyId := ""
+  runID := generateRunId()
+  test_structure.RunTestStage(t, "create_escalation_policy", func() {
+  escalationPolicyId = createEscalationPolicy(t, workingDir, runID)
+  log.Println("created escalation policy ID: ", escalationPolicyId)
+  })
 
-	defer test_structure.RunTestStage(t, "destroy_escalation_policy", func() {
-		destroyEscalationPolicy(t, workingDir)
-	})
+  defer test_structure.RunTestStage(t, "destroy_escalation_policy", func() {
+  destroyEscalationPolicy(t, workingDir)
+  })
 
-	test_structure.RunTestStage(t, "verify_escalation_policy", func() {
-		verifyEscalationPolicy(t, escalationPolicyId)
-	})
+  test_structure.RunTestStage(t, "verify_escalation_policy", func() {
+  verifyEscalationPolicy(t, escalationPolicyId)
+  })
 }
 
 func createEscalationPolicy(t *testing.T, workingDir string, runID string) string {
-	escalationPolicyId := ""
+  escalationPolicyId := ""
 
-	options := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: workingDir,
-		Vars: map[string]interface{}{
-			"schedule_suffix": runID,
-		},
-	})
-	test_structure.SaveTerraformOptions(t, workingDir, options)
-	terraform.InitAndApply(t, options)
-	escalationPolicyId = terraform.Output(t, options, "id")
+  options := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+  TerraformDir: workingDir,
+  Vars: map[string]interface{}{
+    "schedule_suffix": runID,
+  },
+  })
+  test_structure.SaveTerraformOptions(t, workingDir, options)
+  terraform.InitAndApply(t, options)
+  escalationPolicyId = terraform.Output(t, options, "id")
 
-	return escalationPolicyId
+  return escalationPolicyId
 }
 
 func destroyEscalationPolicy(t *testing.T, workingDir string) {
-	terraform.Destroy(t, test_structure.LoadTerraformOptions(t, workingDir))
+  terraform.Destroy(t, test_structure.LoadTerraformOptions(t, workingDir))
 }
 
 func verifyEscalationPolicy(t *testing.T, escalationPolicyId string) {
-	client := pagerduty.NewClient(loadPagerdutyToken(t))
+  client := pagerduty.NewClient(loadPagerdutyToken(t))
 
-	escalationPolicyOptions := pagerduty.GetEscalationPolicyOptions{}
-	escalationPolicy, escalationPolicyErr := client.GetEscalationPolicyWithContext(context.Background(), escalationPolicyId, &escalationPolicyOptions)
-	if escalationPolicyErr != nil {
-		log.Println("error getting escalation policy: ", escalationPolicyErr)
-	}
-	log.Println("escalation policy struct: ", escalationPolicy)
+  escalationPolicyOptions := pagerduty.GetEscalationPolicyOptions{}
+  escalationPolicy, escalationPolicyErr := client.GetEscalationPolicyWithContext(context.Background(), escalationPolicyId, &escalationPolicyOptions)
+  if escalationPolicyErr != nil {
+  log.Println("error getting escalation policy: ", escalationPolicyErr)
+  }
+  log.Println("escalation policy struct: ", escalationPolicy)
 
-	// Expected outcome/values can be seen in the screenshot in the [example's readme](../examples/pagerduty-escalation-policy/README.md)
-	assert.Equal(t, 3, len(escalationPolicy.EscalationRules))
-	assert.Equal(t, 1, len(escalationPolicy.EscalationRules[0].Targets))
-	assert.Equal(t, 2, len(escalationPolicy.EscalationRules[1].Targets))
-	assert.Equal(t, 2, len(escalationPolicy.EscalationRules[2].Targets))
+  // Expected outcome/values can be seen in the screenshot in the [example's readme](../examples/pagerduty-escalation-policy/README.md)
+  assert.Equal(t, 3, len(escalationPolicy.EscalationRules))
+  assert.Equal(t, 1, len(escalationPolicy.EscalationRules[0].Targets))
+  assert.Equal(t, 2, len(escalationPolicy.EscalationRules[1].Targets))
+  assert.Equal(t, 2, len(escalationPolicy.EscalationRules[2].Targets))
+  assert.Lenf(t, escalationPolicy.Teams, 1, "Expect one team is associated with this escalation policy.")
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

Adds the 'teams' input to the escalation-policy module. This input lets us associate Pagerduty teams with escalation policies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-pagerduty-alerting/14)
<!-- Reviewable:end -->
