### PR TITLE
fix: Use count rather than for_each

### DIFF
--- a/.github/workflows/checkov.yaml
+++ b/.github/workflows/checkov.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches: [test, dev, qa, prod, main]
 
+permissions: read-all
+
 jobs:
   checkov:
     name: checkov

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -7,6 +7,8 @@ on:
       - edited
       - synchronize
 
+permissions: read-all
+
 jobs:
   main:
     name: Semantic Pull Request

--- a/.github/workflows/shiftleft-terraform.yaml
+++ b/.github/workflows/shiftleft-terraform.yaml
@@ -7,6 +7,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   shiftleft-terraform:
     runs-on: ubuntu-20.04

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+
+permissions: read-all
+
 env:
   PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
   TF_VAR_pagerduty_token: ${{ secrets.PAGERDUTY_TOKEN }}

--- a/modules/pagerduty-business-service/business-service.tf
+++ b/modules/pagerduty-business-service/business-service.tf
@@ -6,7 +6,7 @@ resource "pagerduty_business_service" "business_service" {
 }
 
 resource "pagerduty_service_dependency" "supporting_services" {
-  for_each = toset(var.supporting_service_ids)
+  count = length(var.supporting_service_ids)
 
   dependency {
     dependent_service {
@@ -14,14 +14,14 @@ resource "pagerduty_service_dependency" "supporting_services" {
       type = pagerduty_business_service.business_service.type
     }
     supporting_service {
-      id   = each.value
+      id   = var.supporting_service_ids[count.index]
       type = "service"
     }
   }
 }
 
 resource "pagerduty_service_dependency" "supporting_business_services" {
-  for_each = toset(var.supporting_business_service_ids)
+  count = length(var.supporting_business_service_ids)
 
   dependency {
     dependent_service {
@@ -29,7 +29,7 @@ resource "pagerduty_service_dependency" "supporting_business_services" {
       type = pagerduty_business_service.business_service.type
     }
     supporting_service {
-      id   = each.value
+      id   = var.supporting_business_service_ids[count.index]
       type = "business_service"
     }
   }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

change `for_each` to `count` since `for_each` requires determined input

plan failure on `for_each`: https://app.terraform.io/app/honestbank/workspaces/incident-management-prod/runs/run-D2cP4uSGHH2eYKCH

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-pagerduty-alerting/16)
<!-- Reviewable:end -->
