### PR TITLE
feat: add input to make it possible to set teams into schedules

### DIFF
--- a/examples/honest-two-level-schedule/inputs.tf
+++ b/examples/honest-two-level-schedule/inputs.tf
@@ -3,6 +3,11 @@ variable "name" {
   type        = string
 }
 
+variable "team_name" {
+  description = "The name of the Team to set for the schedule."
+  type        = string
+}
+
 variable "pagerduty_token" {
   type        = string
   description = "PagerDuty API token."

--- a/examples/honest-two-level-schedule/main.tf
+++ b/examples/honest-two-level-schedule/main.tf
@@ -6,6 +6,13 @@ module "dummy_users" {
   email_address = "pagerduty-schedule-example-user-${count.index}@honestbank.com"
 }
 
+module "dummy_team" {
+  source = "../../modules/pagerduty-team"
+
+  name        = var.team_name
+  description = "${var.name} - this is an example description"
+}
+
 module "schedule" {
   source = "../../modules/honest-two-level-schedule"
 
@@ -21,4 +28,8 @@ module "schedule" {
   time_zone      = "Asia/Bangkok"
 
   user_ids = module.dummy_users.*.id
+
+  team_ids = [
+    module.dummy_team.id
+  ]
 }

--- a/examples/honest-two-level-schedule/outputs.tf
+++ b/examples/honest-two-level-schedule/outputs.tf
@@ -6,6 +6,10 @@ output "level_two_schedule_id" {
   value = module.schedule.level_two_schedule_id
 }
 
+output "team_id" {
+  value = module.dummy_team.id
+}
+
 output "dummy_user_ids" {
   description = "The dummy users created to be placed into rotation."
   value       = module.dummy_users.*.id

--- a/modules/honest-two-level-schedule/README.md
+++ b/modules/honest-two-level-schedule/README.md
@@ -35,6 +35,7 @@ No resources.
 | <a name="input_name"></a> [name](#input\_name) | The name to set for the schedules and the schedule layers. | `string` | n/a | yes |
 | <a name="input_rotation_turn_length_seconds"></a> [rotation\_turn\_length\_seconds](#input\_rotation\_turn\_length\_seconds) | The time in seconds each individual is on-call for. | `number` | n/a | yes |
 | <a name="input_start_datetime"></a> [start\_datetime](#input\_start\_datetime) | The start date and time of the schedule/rotation - format is `2022-03-23T17:00:00+07:00`. | `string` | `"2022-03-23T17:00:00+07:00"` | no |
+| <a name="input_team_ids"></a> [team\_ids](#input\_team\_ids) | (Optional) Pagerduty Teams associated with the schedules. | `list(string)` | `[]` | no |
 | <a name="input_time_zone"></a> [time\_zone](#input\_time\_zone) | The time zone to set for the schedule (eg. `Asia/Bangkok`). | `string` | `"Asia/Bangkok"` | no |
 | <a name="input_user_ids"></a> [user\_ids](#input\_user\_ids) | An ordered list of PagerDuty User IDs to add to the schedule. The individual's order in the schedule depends on the order of this list. | `list(string)` | n/a | yes |
 

--- a/modules/honest-two-level-schedule/inputs.tf
+++ b/modules/honest-two-level-schedule/inputs.tf
@@ -43,3 +43,10 @@ variable "user_ids" {
     error_message = "At least two unique responders are required to build a two-level schedule. Repeated values are not allowed."
   }
 }
+
+variable "team_ids" {
+  description = "(Optional) Pagerduty Teams associated with the schedules."
+  type        = list(string)
+  nullable    = false
+  default     = []
+}

--- a/modules/honest-two-level-schedule/schedule.tf
+++ b/modules/honest-two-level-schedule/schedule.tf
@@ -32,6 +32,7 @@ module "level_one_schedule" {
   user_ids                     = var.user_ids
   start_datetime               = local.level_one_start_datetime_pagerduty_format
   time_zone                    = var.time_zone
+  team_ids                     = var.team_ids
 }
 
 module "level_two_schedule" {
@@ -43,4 +44,5 @@ module "level_two_schedule" {
   user_ids                     = var.user_ids
   start_datetime               = local.level_two_schedule_calculated_offset_start_datetime_pagerduty_format
   time_zone                    = var.time_zone
+  team_ids                     = var.team_ids
 }

--- a/modules/pagerduty-business-service/README.md
+++ b/modules/pagerduty-business-service/README.md
@@ -10,13 +10,13 @@ as well as attaches dependencies that feed in to the business service using the 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | >= 2.2 |
+| <a name="requirement_pagerduty"></a> [pagerduty](#requirement\_pagerduty) | >= 2.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | >= 2.2 |
+| <a name="provider_pagerduty"></a> [pagerduty](#provider\_pagerduty) | >= 2.7 |
 
 ## Modules
 
@@ -34,7 +34,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_description"></a> [description](#input\_description) | The description of the business service. If not set, a placeholder of `Managed by Terraform` will be set. | `string` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | The description of the business service. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name of the business service. | `string` | n/a | yes |
 | <a name="input_owner_team_id"></a> [owner\_team\_id](#input\_owner\_team\_id) | ID of the team that owns this business service. | `string` | n/a | yes |
 | <a name="input_point_of_contact"></a> [point\_of\_contact](#input\_point\_of\_contact) | A string/text description of who to contact regarding this business service. | `string` | `null` | no |

--- a/modules/pagerduty-escalation-policy/README.md
+++ b/modules/pagerduty-escalation-policy/README.md
@@ -34,6 +34,7 @@ No modules.
 | <a name="input_escalation_delay_in_minutes"></a> [escalation\_delay\_in\_minutes](#input\_escalation\_delay\_in\_minutes) | The escalation delay between each layer of the escalation policy. | `any` | n/a | yes |
 | <a name="input_escalation_levels"></a> [escalation\_levels](#input\_escalation\_levels) | A list of a list of schedules. The outer list is mapped to escalation rules, while the inner list represents multiple targets in the same escalation level. | `list(list(string))` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name to set for the schedules and the schedule layers. | `string` | n/a | yes |
+| <a name="input_teams_id"></a> [teams\_id](#input\_teams\_id) | (Optional) Teams associated with the policy. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/pagerduty-schedule/README.md
+++ b/modules/pagerduty-schedule/README.md
@@ -30,6 +30,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | The name to set for the schedule and the base layer. | `string` | n/a | yes |
 | <a name="input_rotation_turn_length_seconds"></a> [rotation\_turn\_length\_seconds](#input\_rotation\_turn\_length\_seconds) | The time in seconds each individual is on-call for. | `number` | n/a | yes |
 | <a name="input_start_datetime"></a> [start\_datetime](#input\_start\_datetime) | The start date and time of the schedule/rotation - format is `2022-03-23T17:00:00+07:00`. | `string` | n/a | yes |
+| <a name="input_team_ids"></a> [team\_ids](#input\_team\_ids) | (Optional) Pagerduty Teams associated with the schedule. | `list(string)` | `[]` | no |
 | <a name="input_time_zone"></a> [time\_zone](#input\_time\_zone) | The time zone to set for the schedule (eg. `Asia/Bangkok`). | `string` | n/a | yes |
 | <a name="input_user_ids"></a> [user\_ids](#input\_user\_ids) | An ordered list of PagerDuty User IDs to add to the schedule. The individual's order in the schedule depends on the order of this list. | `list(string)` | n/a | yes |
 

--- a/modules/pagerduty-schedule/inputs.tf
+++ b/modules/pagerduty-schedule/inputs.tf
@@ -27,3 +27,10 @@ variable "user_ids" {
   description = "An ordered list of PagerDuty User IDs to add to the schedule. The individual's order in the schedule depends on the order of this list."
   type        = list(string)
 }
+
+variable "team_ids" {
+  description = "(Optional) Pagerduty Teams associated with the schedule."
+  type        = list(string)
+  nullable    = false
+  default     = []
+}

--- a/modules/pagerduty-schedule/schedule.tf
+++ b/modules/pagerduty-schedule/schedule.tf
@@ -11,4 +11,6 @@ resource "pagerduty_schedule" "schedule" {
     rotation_turn_length_seconds = var.rotation_turn_length_seconds
     users                        = var.user_ids
   }
+
+  teams = var.team_ids
 }

--- a/modules/pagerduty-team/README.md
+++ b/modules/pagerduty-team/README.md
@@ -25,13 +25,20 @@ No modules.
 | Name | Type |
 |------|------|
 | [pagerduty_team.team](https://registry.terraform.io/providers/pagerduty/pagerduty/latest/docs/resources/team) | resource |
+| [pagerduty_team_membership.managers](https://registry.terraform.io/providers/pagerduty/pagerduty/latest/docs/resources/team_membership) | resource |
+| [pagerduty_team_membership.observers](https://registry.terraform.io/providers/pagerduty/pagerduty/latest/docs/resources/team_membership) | resource |
+| [pagerduty_team_membership.responders](https://registry.terraform.io/providers/pagerduty/pagerduty/latest/docs/resources/team_membership) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_description"></a> [description](#input\_description) | A description of the team. If not set, a placeholder of `Managed by Terraform` will be set. | `string` | n/a | yes |
+| <a name="input_manager_user_ids"></a> [manager\_user\_ids](#input\_manager\_user\_ids) | Pagerduty user IDs of the product manager of this team.<br>    Example: "userid1" | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the team. | `string` | n/a | yes |
+| <a name="input_observer_user_ids"></a> [observer\_user\_ids](#input\_observer\_user\_ids) | List of Pagerduty user IDs of the observers in this team.<br>    Example: [userid1, userid2] | `list(string)` | `[]` | no |
+| <a name="input_parent"></a> [parent](#input\_parent) | (Optional) ID of the parent team. This is available to accounts with the Team Hierarchy feature enabled. | `string` | `null` | no |
+| <a name="input_responder_user_ids"></a> [responder\_user\_ids](#input\_responder\_user\_ids) | List of Pagerduty user IDs of the responder in this team.<br>    Example: [userid1, userid2] | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/pagerduty-user/user.tf
+++ b/modules/pagerduty-user/user.tf
@@ -3,4 +3,10 @@ resource "pagerduty_user" "user" {
   email = var.email_address
 
   role = var.role
+
+  lifecycle {
+    ignore_changes = [
+      job_title # This implies we do not manage Job title in code and will be managed through web UI.
+    ]
+  }
 }

--- a/test/honest_two_level_schedule_test.go
+++ b/test/honest_two_level_schedule_test.go
@@ -1,145 +1,159 @@
 package test
 
 import (
-	"context"
-	"github.com/PagerDuty/go-pagerduty"
-	"github.com/gruntwork-io/terratest/modules/terraform"
-	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
-	"github.com/stretchr/testify/assert"
-	"log"
-	"testing"
-	"time"
+    "context"
+    "fmt"
+    "log"
+    "testing"
+    "time"
+
+    "github.com/PagerDuty/go-pagerduty"
+    "github.com/gruntwork-io/terratest/modules/terraform"
+    test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+    "github.com/stretchr/testify/assert"
 )
 
 func TestHonestTwoLevelSchedule(t *testing.T) {
-	workingDir := test_structure.CopyTerraformFolderToTemp(t, "..", "examples/honest-two-level-schedule")
+    workingDir := test_structure.CopyTerraformFolderToTemp(t, "..", "examples/honest-two-level-schedule")
 
-	levelOneScheduleId := ""
-	levelTwoScheduleId := ""
+    levelOneScheduleId := ""
+    levelTwoScheduleId := ""
+    teamID := ""
 
-	log.Println("working dir for this test is: ", workingDir)
+    log.Println("working dir for this test is: ", workingDir)
 
-	test_structure.RunTestStage(t, "create_two_level_schedule", func() {
-		levelOneScheduleId, levelTwoScheduleId = createTwoLevelScheduleWithUserCount(t, workingDir, 5)
-	})
+    runID := generateRunId()
+    teamName := fmt.Sprintf("Terratest created team - %s", runID)
+    test_structure.RunTestStage(t, "create_two_level_schedule", func() {
+        levelOneScheduleId, levelTwoScheduleId, teamID = createTwoLevelScheduleWithUserCount(t, workingDir, 5, teamName)
+    })
 
-	defer test_structure.RunTestStage(t, "destroy_two_level_schedule", func() {
-		destroyTwoLevelSchedule(t, workingDir)
-	})
+    defer test_structure.RunTestStage(t, "destroy_two_level_schedule", func() {
+        destroyTwoLevelSchedule(t, workingDir)
+    })
 
-	test_structure.RunTestStage(t, "verify_two_level_schedule", func() {
-		verifyTwoLevelScheduleWithUserCount(t, levelOneScheduleId, levelTwoScheduleId, 5)
-	})
+    test_structure.RunTestStage(t, "verify_two_level_schedule", func() {
+        verifyTwoLevelScheduleWithUserCount(t, levelOneScheduleId, levelTwoScheduleId, 5)
+        verifyTeamSetInSchedule(t, levelOneScheduleId, levelTwoScheduleId, teamID)
+    })
 }
 
-func createTwoLevelSchedule(t *testing.T, workingDir string) (string, string) {
-	levelOneScheduleId := ""
-	levelTwoScheduleId := ""
 
-	options := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: workingDir,
-	})
-	test_structure.SaveTerraformOptions(t, workingDir, options)
-	terraform.InitAndApply(t, options)
-	levelOneScheduleId = terraform.Output(t, options, "level_one_schedule_id")
-	levelTwoScheduleId = terraform.Output(t, options, "level_two_schedule_id")
-	return levelOneScheduleId, levelTwoScheduleId
-}
+func createTwoLevelScheduleWithUserCount(t *testing.T, workingDir string, userCount int, teamName string) (string, string, string) {
+    levelOneScheduleId := ""
+    levelTwoScheduleId := ""
 
-func createTwoLevelScheduleWithUserCount(t *testing.T, workingDir string, userCount int) (string, string) {
-	levelOneScheduleId := ""
-	levelTwoScheduleId := ""
+    options := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+        TerraformDir: workingDir,
+        Vars: map[string]interface{}{
+            "dummy_user_count": userCount,
+            "team_name": teamName,
+        },
+    })
+    test_structure.SaveTerraformOptions(t, workingDir, options)
+    terraform.InitAndApply(t, options)
+    levelOneScheduleId = terraform.Output(t, options, "level_one_schedule_id")
+    levelTwoScheduleId = terraform.Output(t, options, "level_two_schedule_id")
+    teamID := terraform.Output(t, options, "team_id")
 
-	options := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: workingDir,
-		Vars: map[string]interface{}{
-			"dummy_user_count": userCount,
-		},
-	})
-	test_structure.SaveTerraformOptions(t, workingDir, options)
-	terraform.InitAndApply(t, options)
-	levelOneScheduleId = terraform.Output(t, options, "level_one_schedule_id")
-	levelTwoScheduleId = terraform.Output(t, options, "level_two_schedule_id")
-	return levelOneScheduleId, levelTwoScheduleId
+    return levelOneScheduleId, levelTwoScheduleId, teamID
 }
 
 func destroyTwoLevelSchedule(t *testing.T, workingDir string) {
-	terraform.Destroy(t, test_structure.LoadTerraformOptions(t, workingDir))
+    terraform.Destroy(t, test_structure.LoadTerraformOptions(t, workingDir))
 }
 
 func verifyTwoLevelScheduleWithUserCount(t *testing.T, levelOneScheduleId string, levelTwoScheduleId string, userCount int) {
-	client := pagerduty.NewClient(loadPagerdutyToken(t))
+    client := pagerduty.NewClient(loadPagerdutyToken(t))
 
-	onCallOptions := pagerduty.ListOnCallUsersOptions{}
+    onCallOptions := pagerduty.ListOnCallUsersOptions{}
 
-	// We check one - 'now' - for the base-case without looping. We set the time interval to 1sec to ensure that we
-	// only get one on-call responder for each schedule.
-	since := time.Now()
-	until := since.Add(1 * time.Second)
+    // We check one - 'now' - for the base-case without looping. We set the time interval to 1sec to ensure that we
+    // only get one on-call responder for each schedule.
+    since := time.Now()
+    until := since.Add(1 * time.Second)
 
-	onCallOptions.Since = since.Format(time.RFC3339)
-	onCallOptions.Until = until.Format(time.RFC3339)
+    onCallOptions.Since = since.Format(time.RFC3339)
+    onCallOptions.Until = until.Format(time.RFC3339)
 
-	log.Println("⏰⏰⏰ checking for on-call since: ", onCallOptions.Since, "// until: ", onCallOptions.Until)
+    log.Println("⏰⏰⏰ checking for on-call since: ", onCallOptions.Since, "// until: ", onCallOptions.Until)
 
-	// Check on-call 'now' - this works for userCount == 2
-	levelOneOnCall, listLevelOneOnCallErr := client.ListOnCallUsersWithContext(context.Background(), levelOneScheduleId, onCallOptions)
-	levelTwoOnCall, listLevelTwoOnCallErr := client.ListOnCallUsersWithContext(context.Background(), levelTwoScheduleId, onCallOptions)
+    // Check on-call 'now' - this works for userCount == 2
+    levelOneOnCall, listLevelOneOnCallErr := client.ListOnCallUsersWithContext(context.Background(), levelOneScheduleId, onCallOptions)
+    levelTwoOnCall, listLevelTwoOnCallErr := client.ListOnCallUsersWithContext(context.Background(), levelTwoScheduleId, onCallOptions)
 
-	if listLevelOneOnCallErr != nil {
-		log.Println("error getting level one on call: ", listLevelOneOnCallErr)
-	}
+    if listLevelOneOnCallErr != nil {
+        log.Println("error getting level one on call: ", listLevelOneOnCallErr)
+    }
 
-	if listLevelTwoOnCallErr != nil {
-		log.Println("error getting level two on call: ", listLevelTwoOnCallErr)
-	}
+    if listLevelTwoOnCallErr != nil {
+        log.Println("error getting level two on call: ", listLevelTwoOnCallErr)
+    }
 
-	assert.Equal(t, 1, len(levelOneOnCall))
-	assert.Equal(t, 1, len(levelTwoOnCall))
+    assert.Equal(t, 1, len(levelOneOnCall))
+    assert.Equal(t, 1, len(levelTwoOnCall))
 
-	// Prevent a panic
-	if len(levelOneOnCall) != 1 || len(levelTwoOnCall) != 1 {
-		t.FailNow()
-	}
+    // Prevent a panic
+    if len(levelOneOnCall) != 1 || len(levelTwoOnCall) != 1 {
+        t.FailNow()
+    }
 
-	log.Println("1️⃣ level 1 on-call is: ", levelOneOnCall[0].ID, " || 2️⃣ level 2 on-call is: ", levelTwoOnCall[0].ID)
-	assert.NotEqual(t, levelOneOnCall[0].ID, levelTwoOnCall[0].ID)
+    log.Println("1️⃣ level 1 on-call is: ", levelOneOnCall[0].ID, " || 2️⃣ level 2 on-call is: ", levelTwoOnCall[0].ID)
+    assert.NotEqual(t, levelOneOnCall[0].ID, levelTwoOnCall[0].ID)
 
-	// Check future rotations to ensure that for at least the next 2*userCount rotations no responder has overlapping
-	// L1 and L2 rotations.
-	for i := 1; i <= 2*userCount; i++ {
-		log.Println("checking future schedule, iteration #", i)
-		since = since.Add(24 * time.Hour)
-		until = since.Add(1 * time.Second)
+    // Check future rotations to ensure that for at least the next 2*userCount rotations no responder has overlapping
+    // L1 and L2 rotations.
+    for i := 1; i <= 2*userCount; i++ {
+        log.Println("checking future schedule, iteration #", i)
+        since = since.Add(24 * time.Hour)
+        until = since.Add(1 * time.Second)
 
-		onCallOptions.Since = since.Format(time.RFC3339)
-		onCallOptions.Until = until.Format(time.RFC3339)
+        onCallOptions.Since = since.Format(time.RFC3339)
+        onCallOptions.Until = until.Format(time.RFC3339)
 
-		log.Println("➡️ future check, iteration #", i, " - checking for on-call since: ", onCallOptions.Since, "// until: ", onCallOptions.Until)
+        log.Println("➡️ future check, iteration #", i, " - checking for on-call since: ", onCallOptions.Since, "// until: ", onCallOptions.Until)
 
-		levelOneOnCall, listLevelOneOnCallErr = client.ListOnCallUsersWithContext(context.Background(), levelOneScheduleId, onCallOptions)
-		levelTwoOnCall, listLevelTwoOnCallErr = client.ListOnCallUsersWithContext(context.Background(), levelTwoScheduleId, onCallOptions)
+        levelOneOnCall, listLevelOneOnCallErr = client.ListOnCallUsersWithContext(context.Background(), levelOneScheduleId, onCallOptions)
+        levelTwoOnCall, listLevelTwoOnCallErr = client.ListOnCallUsersWithContext(context.Background(), levelTwoScheduleId, onCallOptions)
 
-		if listLevelOneOnCallErr != nil {
-			log.Println("error getting level one on call: ", listLevelOneOnCallErr)
-		}
+        if listLevelOneOnCallErr != nil {
+            log.Println("error getting level one on call: ", listLevelOneOnCallErr)
+        }
 
-		if listLevelTwoOnCallErr != nil {
-			log.Println("error getting level two on call: ", listLevelTwoOnCallErr)
-		}
+        if listLevelTwoOnCallErr != nil {
+            log.Println("error getting level two on call: ", listLevelTwoOnCallErr)
+        }
 
-		assert.Equal(t, 1, len(levelOneOnCall))
-		assert.Equal(t, 1, len(levelTwoOnCall))
+        assert.Equal(t, 1, len(levelOneOnCall))
+        assert.Equal(t, 1, len(levelTwoOnCall))
 
-		// Prevent a panic
-		if len(levelOneOnCall) != 1 || len(levelTwoOnCall) != 1 {
-			t.FailNow()
-		}
+        // Prevent a panic
+        if len(levelOneOnCall) != 1 || len(levelTwoOnCall) != 1 {
+            t.FailNow()
+        }
 
-		log.Println("1️⃣ level 1 on-call is: ", levelOneOnCall[0].ID, " || 2️⃣ level 2 on-call is: ", levelTwoOnCall[0].ID)
-		assert.NotEqual(t, levelOneOnCall[0].ID, levelTwoOnCall[0].ID)
+        log.Println("1️⃣ level 1 on-call is: ", levelOneOnCall[0].ID, " || 2️⃣ level 2 on-call is: ", levelTwoOnCall[0].ID)
+        assert.NotEqual(t, levelOneOnCall[0].ID, levelTwoOnCall[0].ID)
 
-		// TODO: Check that the same user isn't scheduled consecutively (not sure if this is an issue though). The test is
-		// 		 already complicated enough.
-	}
+        // TODO: Check that the same user isn't scheduled consecutively (not sure if this is an issue though). The test is
+        // 		 already complicated enough.
+    }
+}
+
+// verifyTeamSetInSchedule verifies whether the schedule created have set a team ID as expected.
+func verifyTeamSetInSchedule(t  *testing.T, levelOneScheduleID string, levelTwoScheduleID string, expectedTeamID string) {
+   client := pagerduty.NewClient(loadPagerdutyToken(t))
+   getScheduleOptions := pagerduty.GetScheduleOptions{}
+
+   schedule1, errGettingSchedule1 := client.GetScheduleWithContext(context.Background(), levelTwoScheduleID, getScheduleOptions)
+   schedule2, errGettingSchedule2 := client.GetScheduleWithContext(context.Background(), levelTwoScheduleID, getScheduleOptions)
+
+    assert.Nilf(t, errGettingSchedule1, "Error fetching schedule 1 in verifyTeamSetInSchedule")
+    assert.Nilf(t, errGettingSchedule2, "Error fetching schedule 2 in verifyTeamSetInSchedule")
+
+    assert.Lenf(t, schedule1.Teams, 1, "Teams of schedule 1 is not 1, expected one team set.")
+    assert.Lenf(t, schedule2.Teams, 1, "Teams of schedule 2 is not 1, expected 1 team set.")
+
+   assert.Equalf(t, schedule1.Teams[0].ID, expectedTeamID, "Expected team ID in schedule 1 not correct")
+   assert.Equalf(t, schedule2.Teams[0].ID, expectedTeamID, "Expected team ID in schedule 2 not correct")
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [X] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [X] I have typed an adequate description that explains **why** I am making this change.
- [X] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

The goal of this PR is twofold:
* Add an input to make it possible to specify Pagerduty teams associated to Pagerduty schedules. So far this is not possible as we are not passing any value to the property to specify the Pagerduty teams associated to a schedule.
* In practice this is causing an annoying drift, as Pagerduty is setting by itself the teams of an schedule as the teams associated with the escalation policy of the schedule. But because in Terraform we are not passing any team, this causes a drift in which Terraform wants to clear the teams of the schedules. After this PR, if the team schedules are not set, they default to `[]` so the drift should be gone.
* It was not in the original purpose of this PR but also add `ignore_changes` to the job title of Pagerduty users to avoid drift.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-pagerduty-alerting/17)
<!-- Reviewable:end -->
