### PR TITLE
fix: use count instead of for_each for responder_user_ids in pagerduty_team_membership( DEC-2926 )

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -18,3 +18,4 @@ jobs:
         name: Semantic Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/modules/pagerduty-team/membership.tf
+++ b/modules/pagerduty-team/membership.tf
@@ -6,9 +6,9 @@ locals {
 }
 
 resource "pagerduty_team_membership" "responders" {
-  for_each = toset(var.responder_user_ids)
+  count = length(var.responder_user_ids)
 
-  user_id = each.key
+  user_id = var.responder_user_ids[count.index]
   team_id = pagerduty_team.team.id
   role    = local.CONST_RESPONDER_ROLE
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [X] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [X] I have typed an adequate description that explains **why** I am making this change.
- [X] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

Terraform run on incident-managment throwing error - https://app.terraform.io/app/honestbank/workspaces/incident-management-prod/runs/run-yGNE9Pofo3PSQhcR
This fix here, fixes the issue and will produce a successful run - https://app.terraform.io/app/honestbank/workspaces/incident-management-prod/runs/run-q8miqP4iqqxnKa17

All we do in this PR is when creating the pagerduty_team_membership.responders, we are using count instead of for_each.

<!--

A description is required for all PRs :) Please try to provide background/context to the reviewer in order to get
a more relevant/effective review.

-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-pagerduty-alerting/26)
<!-- Reviewable:end -->
